### PR TITLE
chore(SBTree): updated to 2.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Expected Behavior
+
+Please describe the behavior you are expecting
+
+### Current Behavior
+
+What is the current behavior?
+
+### Context
+
+Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.
+
+### Steps to Reproduce & logs
+
+If case of a bug, please list here how to reproduce along with logs or code snippets.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Issue being fixed or implemented  
+
+Please include a summary of what is the issue being fixed, along with the relevant motivation and context.
+List any dependencies that are required for this change.
+
+### What was done  
+
+Please include a summary of the change
+
+### How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
+
+- [ ] Test A
+- [ ] Test B
+
+### Notes  
+
+
+### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Adapters available for In-Memory and FS store.
  
 N.B : Fields are indexed by default. Specifically exclude field that might be too lengthy as otherwise might have heavy performance effect (see more on BTree to understand).  
 Uniques field are also available.   
+TyrDB relies on [SBTree](https://github.com/Alex-Werner/SBTree) as it's main dependencies for data.  
 
 ### Table of Contents
  - [Installation](#installation)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tyrdb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -754,9 +754,9 @@
       "dev": true
     },
     "sbtree": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sbtree/-/sbtree-1.3.0.tgz",
-      "integrity": "sha512-ZIHO50VimF5snfCJnd4SvwPdoRAGRmb0byjU0rQO1HvrhoKzJ7VbmzI9ZLBLROHIH3VciPah6H+Cxnku0GDuZA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sbtree/-/sbtree-2.0.0.tgz",
+      "integrity": "sha512-/50m9CI4h2+uYxwrfvpAYsc0akfHW+irqCvlKa9JMnjg8yE+G1c3N8qEdsHmTT8zwlRsPSOCOxcJuarA7s8neQ==",
       "requires": {
         "fslockjs": "^1.3.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tyrdb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fast document oriented NodeJS database for node and browser. Allow adapters for in-memory, fs (JSON based or optimized), localStorage.",
   "main": "index.js",
   "scripts": {
@@ -38,7 +38,7 @@
     "fslockjs": "^1.3.0",
     "lodash": "^4.17.15",
     "mongo-objectid": "^1.1.0",
-    "sbtree": "^1.3.0"
+    "sbtree": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/types/Collection/Collection.js
+++ b/test/types/Collection/Collection.js
@@ -18,6 +18,6 @@ describe('Type - Collection', () => {
     expect(colExclude.getTree().exclude).to.be.deep.equal(['email'])
 
     const colOrder = new Collection({name:'users', tyrInstance:fakeTyrInstance,order:25})
-    expect(colOrder.getTree().options.order).to.be.deep.equal(25)
+    expect(colOrder.getTree().order).to.be.deep.equal(25)
   });
 });

--- a/test/types/TyrDB.js
+++ b/test/types/TyrDB.js
@@ -35,7 +35,7 @@ describe('TyrDB - Class', () => {
     expect(tyr.options).to.deep.equal({path: '.db', autoInitialize: true, autoConnect: true});
     expect(tyr.persistanceAdapter).to.deep.equal(new MemoryAdapter())
     expect(tyr.databases).to.deep.equal([])
-    expect(tyr.databaseVersion).to.deep.equal('2.0.0');
+    expect(tyr.databaseVersion).to.deep.equal('2.0.1');
     tyr.on('ready', () => {
       expect(tyr.state).to.deep.equal({
         isConnected: true,
@@ -159,7 +159,7 @@ describe('TyrDB - Class', () => {
     expect(docFromObjectid).to.deep.equal([helloDoc])
   });
   it('should serialize Meta of TyrDB', async function () {
-    const expected = {"options":{"path":".db","autoInitialize":true,"autoConnect":true},"state":{"isConnected":true,"isConnecting":false},"adapter":{"name":"MemoryAdapter"},"databases":[],"databaseVersion":"2.0.0"};
+    const expected = {"options":{"path":".db","autoInitialize":true,"autoConnect":true},"state":{"isConnected":true,"isConnecting":false},"adapter":{"name":"MemoryAdapter"},"databases":[],"databaseVersion":"2.0.1"};
     const client = new TyrDB();
     await client.connect();
     const db = await client.db('tyrdb');


### PR DESCRIPTION
This PR updates SBTree to it's last release. 

One of the most interessant added features is the handling of removal. 

See here the whole list : 

https://github.com/Alex-Werner/SBTree/pull/4

See MVP Feature specs : https://github.com/Alex-Werner/SBTree/projects/1 

Notes : 
Result from benchmark as ran by travis. 

```
TyrDB - Performance - Benchmark within test 
Will process 2600 elements
Finished writeOp in 156.364496 ms [16627.81556242793] ops
Finished getOp in 19.162132 ms [135684.27563279495] ops
Finished findOp in 152.338274 ms [17067.280150489296] ops
    ✓ should be fast (337ms)

======== TyrDB 2.0.1 - Benchmark from mocha
= Write : 16627.81556242793 op/s [2600]
= Get : 135684.27563279495 op/s [2600]
= Find : 17067.280150489296 op/s [2600]
= Total : 7800 operations
= Duration : 0.327864902 s
= Avg : 56459.79044857072 op/s
```