### PR TITLE
fix(findCollection): allow to pass along options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,19 @@ async function start(){
  await client.connect();
  console.log('In sync with the adapter/server');
  const db = await client.db('myproject');
- const col = await db.collection('users');
- const insertedDoc = await col.find({age:33});
+  
+ const doc = {
+  name: 'Jean',
+  age: 33,
+  nestedObject:{isNested:true}
+}
+  // Allow to pass along SBTree options
+ const opts = {exclude:['nestedObject']};
+ const col = await db.collection('users', opts);
+
+ const insertedDoc = await col.insert(doc);
+ const search = await col.find({age:33}); //[{name:"Jean",age:33, nestedObject:{isNested:true}]
+
  await client.close();
 }
 start();

--- a/src/adapters/FsAdapter/methods/findCollection.js
+++ b/src/adapters/FsAdapter/methods/findCollection.js
@@ -14,7 +14,7 @@ module.exports = async function findCollection(tyrInstance, dbName, colName, opt
         return col;
     }
     const meta = await this.queue.add('File.read',path).getResults();
-    col = new Collection(Object.assign(meta,{ adapter:this, tyrInstance}));
+    col = new Collection(Object.assign(meta,{ adapter:this, tyrInstance}, opts));
 
     return new Promise((resolve)=>{
         col.emitter.on('ready', ()=>{


### PR DESCRIPTION
### Issue being fixed or implemented  

SBTree allow to pass along options such as exclude, uniques etc... 
Passing theses are expected as a second arg of `db.collection()`; however these were not passed along correctly. 
This PR fix that.

### What was done  

Correctly pass along opts to SBTree.
