### PR TITLE
Feat: replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ async function start(){
 
  const insertedDoc = await col.insert(doc);
  const search = await col.find({age:33}); //[{name:"Jean",age:33, nestedObject:{isNested:true}]
+ const [jean] = search;
+  jean.age = 34;
+ await col.replace(jean);
 
  await client.close();
 }

--- a/doc/api.md
+++ b/doc/api.md
@@ -3,7 +3,7 @@
 # TyrDB
 
 ```js
-const client = new TyrDB([opts]);
+const tyrClient = new TyrDB([opts]);
 ```
 - Constructor options :
   - `adapter` Adapter - (def: MemoryAdapter()) : Allow to specific another adapter to use
@@ -11,22 +11,17 @@ const client = new TyrDB([opts]);
   - `autoConnect` Adapter - (def: true) : If true, will auto connect the db
   - `path` Adapter - (def: '.db') : Desired relative path to persist the data
 
-# Close connection 
-
-```js
- await client.close();
-```
 
 # Create Database
 
 ```js
-  const db = await client.db('myDb');
+  const db = await tyrClient.db('myDb');
 ```
 
 # Create Collection
 
 ```js
-const db = await client.db('myDb');
+const db = await tyrClient.db('myDb');
 const opts = {};
 const users = await db.collection('users', opts);
 ```
@@ -61,6 +56,17 @@ start();
 
 See more on the valid [Queries](/doc/queries.md)
 
+# Get document
+
+```
+async function getUserById(id){
+ const users = await db.collection('users');
+ const user = await users.get(id);
+ client.close();
+}
+start();
+```
+
 # Remove document
 
 ```
@@ -72,4 +78,34 @@ async function insertUser(){
 }
 start();
 ```
+
+# Replace a document
+
+```
+async function replaceUser(){
+ const users = await db.collection('users');
+ const [alex] = await users.find({firstname:'Alex'});
+ alex.age = 34;
+ await await users.replace(alex);
+ 
+ client.close();
+}
+start();
+```
+
+# Close connection 
+
+```js
+ await tyrClient.close();
+```
+
+
+# Serialize Meta  
+
+Returns the serialized metadata of TyrDB. With adapter options (which using in-mem adapter is a full dump equivalent).
+
+```js
+ await tyrClient.serializeMeta();
+```
+
 

--- a/examples/inmem-usage.js
+++ b/examples/inmem-usage.js
@@ -17,7 +17,7 @@ async function start() {
 
   // Inserting a document
   await col.insert({
-    "name": "Devan",
+    "firstname": "Devan",
     "age": 38,
     "gender": "Male",
     "country": "Georgia",
@@ -26,7 +26,7 @@ async function start() {
 
   // Inserting any document without a _id will generate it one
   const insertedDoc = await col.insert({
-    "name": "Lilith",
+    "firstname": "Lilith",
     "age": 25,
     "gender": "Female",
     "country": "Armenia",
@@ -52,7 +52,7 @@ async function start() {
 
 
   console.log(`Searching Bob`)
-  console.log(await col.find({name:'Bob'}));
+  console.log(await col.find({firstname:'Bob'}));
 
   console.log(`\n Searching age >=45`)
   console.log(await col.find({age: {$gte: 45}}));
@@ -71,9 +71,15 @@ async function start() {
   console.log(await col.get(insertedDocId));
 
   console.log('\n Removing document')
-  console.log(await col.remove({name:'Bob'}));
-  console.log(await col.find({name:'Bob'}));
+  console.log(await col.remove({firstname:'Bob'}));
+  console.log(await col.find({firstname:'Bob'}));
 
+  console.log('\n Replacing a document');
+  const [brigitte] = await col.find({firstname:users.Brigitte.firstname})
+
+  brigitte.country = 'Belgium';
+  await col.replace(brigitte);
+  console.log(await col.find({firstname:users.Brigitte.firstname}))
 
   await client.close();
 }

--- a/examples/users.json
+++ b/examples/users.json
@@ -1,48 +1,48 @@
 {
   "Alex": {
-    "name": "Alex",
+    "firstname": "Alex",
     "age": 27,
     "country": "France",
     "gender": "Male"
   },
   "Jean": {
-    "name": "Jean",
+    "firstname": "Jean",
     "age": 34,
     "country": "France",
     "gender": "Male"
   },
   "Alice": {
-    "name": "Alice",
+    "firstname": "Alice",
     "age": 36,
     "country": "United States",
     "gender": "Female"
   },
   "Bob": {
-    "name": "Bob",
+    "firstname": "Bob",
     "age": 45,
     "country": "United States",
     "gender": "Male"
   },
   "Pascal": {
-    "name": "Pascal",
+    "firstname": "Pascal",
     "age": 41,
     "country": "Switzerland",
     "gender": "Male"
   },
   "Anastasia": {
-    "name": "Anastasia",
+    "firstname": "Anastasia",
     "age": 34,
     "country": "Russia",
     "gender": "Female"
   },
   "Lucy": {
-    "name": "Lucy",
+    "firstname": "Lucy",
     "age": 23,
     "country": "Hong Kong",
     "gender": "Female"
   },
   "Taneti": {
-    "name": "Teneti",
+    "firstname": "Teneti",
     "age": 43,
     "country": "Kiribati",
     "gender": "Female"

--- a/package-lock.json
+++ b/package-lock.json
@@ -754,9 +754,9 @@
       "dev": true
     },
     "sbtree": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sbtree/-/sbtree-2.1.1.tgz",
-      "integrity": "sha512-/jm8XS35TZMbS8GJbyCyuhIen7XA8LOSRop+FceY5Xfn9KCK4Mtg9asGQCV6gY0fi418DCVsgMNDOTnMvv82pw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sbtree/-/sbtree-2.2.0.tgz",
+      "integrity": "sha512-GEERgUxrAbqveL826ZfGLa2QJQhmCRz29eDcDQdPOykyqZMPEMjz/LKaQIMly3wi12eJhIcfqB2YB+JVepn93g==",
       "requires": {
         "fslockjs": "^1.3.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fslockjs": "^1.3.0",
     "lodash": "^4.17.15",
     "mongo-objectid": "^1.1.0",
-    "sbtree": "^2.1.1"
+    "sbtree": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/types/Collection/Collection.js
+++ b/src/types/Collection/Collection.js
@@ -59,6 +59,7 @@ Collection.prototype.get = require('./methods/get')
 Collection.prototype.find = require('./methods/find')
 Collection.prototype.insert = require('./methods/insert')
 Collection.prototype.remove = require('./methods/remove')
+Collection.prototype.replace = require('./methods/replace')
 Collection.prototype.insertMany = require('./methods/insertMany')
 Collection.prototype.insertOne = require('./methods/insertOne')
 module.exports = Collection;

--- a/src/types/Collection/methods/replace.js
+++ b/src/types/Collection/methods/replace.js
@@ -1,0 +1,3 @@
+module.exports = async function replace(document){
+  return await this.getTree().replaceDocuments(document);
+}

--- a/src/types/Collection/methods/replaceOne.js
+++ b/src/types/Collection/methods/replaceOne.js
@@ -1,3 +1,0 @@
-module.exports = function replaceOne(selector = {}, document, opts = {}){
-  throw new Error('Not implemented');
-}


### PR DESCRIPTION
### Issue being fixed or implemented  

Previously, replacing a document were requiring to first removeDocument and then insertDocument being careful to use similar id. 
This PR allow to provide a replaceDocument (that will lookup the field added, deleted, changed, and only perform modification on them) method.

### What was done  

- Updated documentation 
- Updated SBTree to support replace method.